### PR TITLE
use different scattering method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - python3 -m pip install pytest-workflow
 
 script:
-  - python3 -m pytest --tag $TEST tests/
+  - travis_wait 30 python3 -m pytest --tag $TEST tests/
 
 matrix:
   include:

--- a/mutect2.wdl
+++ b/mutect2.wdl
@@ -18,7 +18,7 @@ workflow Mutect2 {
         Map[String, String] dockerTags = {
             "picard":"2.18.26--0",
             "biopet-scatterregions": "0.2--0",
-            "gatk": "4.1.0.0--0"
+            "gatk4": "4.1.0.0--0"
         }
     }
 
@@ -49,7 +49,7 @@ workflow Mutect2 {
                 tumorSample = tumorSample,
                 normalSample = controlSample,
                 intervals = [bed],
-                dockerTag = dockerTags["gatk"]
+                dockerTag = dockerTags["gatk4"]
         }
 
         File mutectFiles = mutect2.vcfFile.file

--- a/somatic-variantcalling.wdl
+++ b/somatic-variantcalling.wdl
@@ -25,7 +25,7 @@ workflow SomaticVariantcalling {
             "tabix": "0.2.6--ha92aebf_0",
             "manta": "1.4.0--py27_1",
             "strelka": "2.9.7--0",
-            "gatk": "4.1.0.0--0",
+            "gatk4": "4.1.0.0--0",
             "vardict": "1.5.8--1"
         }
     }

--- a/somatic-variantcalling.wdl
+++ b/somatic-variantcalling.wdl
@@ -26,7 +26,7 @@ workflow SomaticVariantcalling {
             "manta": "1.4.0--py27_1",
             "strelka": "2.9.7--0",
             "gatk4": "4.1.0.0--0",
-            "vardict": "1.5.8--1"
+            "vardict-java": "1.5.8--1"
         }
     }
 

--- a/vardict.wdl
+++ b/vardict.wdl
@@ -27,13 +27,10 @@ workflow VarDict{
         then "~{tumorSample}-~{controlSample}"
         else tumorSample
 
-    call biopet.ScatterRegions as scatterList {
+    call chunkedScatter as scatterList {
         input:
-            reference = reference,
-            regions = regions,
-            bamFile = tumorBam.file,
-            bamIndex = tumorBam.index,
-            dockerTag = dockerTags["biopet-scatterregions"]
+            inputIsBed = defined(regions),
+            fastaDict = reference.dict
     }
 
     scatter (bed in scatterList.scatters){
@@ -60,5 +57,104 @@ workflow VarDict{
 
     output {
         IndexedVcfFile outputVCF = gatherVcfs.outputVcf
+    }
+}
+
+task chunkedScatter {
+    input {
+        Int chunkSize = 1000000
+        Int minimumSizePerFile = 45000000
+        Int overlap = 150
+        Boolean inputIsBed = false
+        File fastaDict
+
+        String dockerTag = "3.7-slim"
+    }
+
+    String outDir = "scatters"
+
+    command <<<
+        python <<CODE
+           from pathlib import Path
+
+           chunk_size = ~{chunkSize}
+           minimum_size_per_file = ~{minimumSizePerFile}
+           overlap = ~{overlap}
+           out_dir = "~{outDir}"
+           in_path = Path("~{fastaDict}")
+           bed_input = ~{true="True" false="False" inputIsBed}
+
+           def dict_chunker(f):
+               for line in f.readlines():
+                   line = line.split()
+                   if line[0] == "@SQ":
+                       for field in line:
+                           if field[:2] == "LN":
+                               length = int(field.split(":")[1])
+                           elif field[:2] == "SN":
+                               name = ":".join(field.split(":")[1:])
+                       # This will cause the last chunk to be between 0.5 and 1.5
+                       # times the chunk_size in length, this way we avoid the
+                       # possibility that the last chunk ends up being to small
+                       # (eg. 1+overlap bases).
+                       position = 0
+                       while position + chunk_size*1.5 < length:
+                           yield [name, position-overlap, position+chunk_size]
+                           position += chunk_size
+                       yield [name, position-overlap, length]
+
+
+           def bed_chunker(f):
+               for line in f.readlines():
+                   line = line.strip().split("\t")
+                   if line[0] not in ["browser", "track"] and len(line) >= 3:
+                       start = int(line[1])
+                       end = int(line[2])
+                       name = line[0]
+                       position = start
+                       # This will cause the last chunk to be between 0.5 and 1.5
+                       # times the chunk_size in length, this way we avoid the
+                       # possibility that the last chunk ends up being to small
+                       # (eg. 1+overlap bases).
+                       while position + chunk_size*1.5 < end:
+                           if position-overlap <= start:
+                               yield [name, start, position+chunk_size]
+                           else:
+                               yield [name, position-overlap, position+chunk_size]
+                           position += chunk_size
+                       yield [name, position-overlap, end]
+
+
+           current_scatter = 0
+           current_scatter_size = 0
+           current_contig = None
+
+           out_file = open("{}/scatter-{}.bed".format(out_dir, current_scatter), "w")
+           with in_path.open("r") as in_file:
+               chunks = bed_chunker(in_file) if bed_input else dict_chunker(in_file)
+               for chunk in chunks:
+                   if chunk[1] < 0:
+                       chunk[1] = 0
+                   if chunk[0] != current_contig:
+                       current_contig = chunk[0]
+                       if current_scatter_size >= minimum_size_per_file:
+                           out_file.close()
+                           current_scatter += 1
+                           current_scatter_size = 0
+                           out_file = open("{}/scatter-{}.bed".format(out_dir,
+                               current_scatter), "w")
+                   out_file.write("{}\t{}\t{}\n".format(chunk[0], chunk[1], chunk[2]))
+                   current_scatter_size += (chunk[2]-chunk[1])
+               out_file.close()
+    >>>
+
+    output {
+        Array[File] scatters = glob(outputDirPath + "/scatter-*.bed")
+    }
+
+    runtime {
+        docker: "python:" + dockerTag
+        # 4 gigs of memory to be able to build the docker image in singularity
+        memory: 4
     }
 }

--- a/vardict.wdl
+++ b/vardict.wdl
@@ -1,6 +1,5 @@
 version 1.0
 
-import "tasks/biopet/biopet.wdl" as biopet
 import "tasks/picard.wdl" as picard
 import "tasks/samtools.wdl" as samtools
 import "tasks/vardict.wdl" as vardict
@@ -74,82 +73,87 @@ task chunkedScatter {
     String outDir = "scatters"
 
     command <<<
+        mkdir -p ~{outDir}
         python <<CODE
-           from pathlib import Path
+        from pathlib import Path
 
-           chunk_size = ~{chunkSize}
-           minimum_size_per_file = ~{minimumSizePerFile}
-           overlap = ~{overlap}
-           out_dir = "~{outDir}"
-           in_path = Path("~{fastaDict}")
-           bed_input = ~{true="True" false="False" inputIsBed}
+        chunk_size = ~{chunkSize}
+        minimum_size_per_file = ~{minimumSizePerFile}
+        overlap = ~{overlap}
+        out_dir = "~{outDir}"
+        in_path = Path("~{fastaDict}")
+        bed_input = ~{true="True" false="False" inputIsBed}
 
-           def dict_chunker(f):
-               for line in f.readlines():
-                   line = line.split()
-                   if line[0] == "@SQ":
-                       for field in line:
-                           if field[:2] == "LN":
-                               length = int(field.split(":")[1])
-                           elif field[:2] == "SN":
-                               name = ":".join(field.split(":")[1:])
-                       # This will cause the last chunk to be between 0.5 and 1.5
-                       # times the chunk_size in length, this way we avoid the
-                       # possibility that the last chunk ends up being to small
-                       # (eg. 1+overlap bases).
-                       position = 0
-                       while position + chunk_size*1.5 < length:
-                           yield [name, position-overlap, position+chunk_size]
-                           position += chunk_size
-                       yield [name, position-overlap, length]
-
-
-           def bed_chunker(f):
-               for line in f.readlines():
-                   line = line.strip().split("\t")
-                   if line[0] not in ["browser", "track"] and len(line) >= 3:
-                       start = int(line[1])
-                       end = int(line[2])
-                       name = line[0]
-                       position = start
-                       # This will cause the last chunk to be between 0.5 and 1.5
-                       # times the chunk_size in length, this way we avoid the
-                       # possibility that the last chunk ends up being to small
-                       # (eg. 1+overlap bases).
-                       while position + chunk_size*1.5 < end:
-                           if position-overlap <= start:
-                               yield [name, start, position+chunk_size]
-                           else:
-                               yield [name, position-overlap, position+chunk_size]
-                           position += chunk_size
-                       yield [name, position-overlap, end]
+        def dict_chunker(f):
+            for line in f.readlines():
+                line = line.split()
+                if line[0] == "@SQ":
+                    for field in line:
+                        if field[:2] == "LN":
+                            length = int(field.split(":")[1])
+                        elif field[:2] == "SN":
+                            name = ":".join(field.split(":")[1:])
+                    # This will cause the last chunk to be between 0.5 and 1.5
+                    # times the chunk_size in length, this way we avoid the
+                    # possibility that the last chunk ends up being to small
+                    # (eg. 1+overlap bases).
+                    position = 0
+                    while position + chunk_size*1.5 < length:
+                        yield [name, position-overlap, position+chunk_size]
+                        position += chunk_size
+                    yield [name, position-overlap, length]
 
 
-           current_scatter = 0
-           current_scatter_size = 0
-           current_contig = None
+        def bed_chunker(f):
+            for line in f.readlines():
+                line = line.strip().split("\t")
+                if line[0] not in ["browser", "track"] and len(line) >= 3:
+                    start = int(line[1])
+                    end = int(line[2])
+                    name = line[0]
+                    position = start
+                    # This will cause the last chunk to be between 0.5 and 1.5
+                    # times the chunk_size in length, this way we avoid the
+                    # possibility that the last chunk ends up being to small
+                    # (eg. 1+overlap bases).
+                    while position + chunk_size*1.5 < end:
+                        if position-overlap <= start:
+                            yield [name, start, position+chunk_size]
+                        else:
+                            yield [name, position-overlap, position+chunk_size]
+                        position += chunk_size
+                    if position-overlap <= start:
+                        yield [name, start, position+chunk_size]
+                    else:
+                        yield [name, position-overlap, position+chunk_size]
 
-           out_file = open("{}/scatter-{}.bed".format(out_dir, current_scatter), "w")
-           with in_path.open("r") as in_file:
-               chunks = bed_chunker(in_file) if bed_input else dict_chunker(in_file)
-               for chunk in chunks:
-                   if chunk[1] < 0:
-                       chunk[1] = 0
-                   if chunk[0] != current_contig:
-                       current_contig = chunk[0]
-                       if current_scatter_size >= minimum_size_per_file:
-                           out_file.close()
-                           current_scatter += 1
-                           current_scatter_size = 0
-                           out_file = open("{}/scatter-{}.bed".format(out_dir,
-                               current_scatter), "w")
-                   out_file.write("{}\t{}\t{}\n".format(chunk[0], chunk[1], chunk[2]))
-                   current_scatter_size += (chunk[2]-chunk[1])
-               out_file.close()
+
+        current_scatter = 0
+        current_scatter_size = 0
+        current_contig = None
+
+        out_file = open("{}/scatter-{}.bed".format(out_dir, current_scatter), "w")
+        with in_path.open("r") as in_file:
+            chunks = bed_chunker(in_file) if bed_input else dict_chunker(in_file)
+            for chunk in chunks:
+                if chunk[1] < 0:
+                    chunk[1] = 0
+                if chunk[0] != current_contig:
+                    current_contig = chunk[0]
+                    if current_scatter_size >= minimum_size_per_file:
+                        out_file.close()
+                        current_scatter += 1
+                        current_scatter_size = 0
+                        out_file = open("{}/scatter-{}.bed".format(out_dir,
+                            current_scatter), "w")
+                out_file.write("{}\t{}\t{}\n".format(chunk[0], chunk[1], chunk[2]))
+                current_scatter_size += (chunk[2]-chunk[1])
+            out_file.close()
+        CODE
     >>>
 
     output {
-        Array[File] scatters = glob(outputDirPath + "/scatter-*.bed")
+        Array[File] scatters = glob(outDir + "/scatter-*.bed")
     }
 
     runtime {

--- a/vardict.wdl
+++ b/vardict.wdl
@@ -29,7 +29,9 @@ workflow VarDict{
     call chunkedScatter as scatterList {
         input:
             inputIsBed = defined(regions),
-            fastaDict = reference.dict
+            inputFile = if defined(regions)
+             then select_first([regions])
+             else reference.dict
     }
 
     scatter (bed in scatterList.scatters){
@@ -65,7 +67,7 @@ task chunkedScatter {
         Int minimumSizePerFile = 45000000
         Int overlap = 150
         Boolean inputIsBed = false
-        File fastaDict
+        File inputFile
 
         String dockerTag = "3.7-slim"
     }
@@ -81,7 +83,7 @@ task chunkedScatter {
         minimum_size_per_file = ~{minimumSizePerFile}
         overlap = ~{overlap}
         out_dir = "~{outDir}"
-        in_path = Path("~{fastaDict}")
+        in_path = Path("~{inputFile}")
         bed_input = ~{true="True" false="False" inputIsBed}
 
         def dict_chunker(f):

--- a/vardict.wdl
+++ b/vardict.wdl
@@ -18,7 +18,7 @@ workflow VarDict{
         Map[String, String] dockerTags = {
             "picard":"2.18.26--0",
             "biopet-scatterregions": "0.2--0",
-            "vardict": "1.5.8--1"
+            "vardict-java": "1.5.8--1"
         }
     }
 
@@ -44,7 +44,7 @@ workflow VarDict{
                 reference = reference,
                 bedFile = bed,
                 outputVcf = prefix + "-" + basename(bed) + ".vcf",
-                dockerTag = dockerTags["vardict"]
+                dockerTag = dockerTags["vardict-java"]
         }
     }
 


### PR DESCRIPTION
This will essentially scatter by chromosome (small chromosomes will be put together), but, in each bed file, the region will be cut up into multiple chunks. These chunks overlap in order to accommodate for indels spanning the border. 

Unless I'm mistaken this should allow vardict to run in low numbers of scatters without running into memory issues. 