### PR TITLE
update default GATK (4.1.2.0) and picard (2.19.0) versions concerning Mutect2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,4 +11,4 @@ that users understand how the changes affect the new version.
 
 version 1.0.0-dev
 ---------------------------
-+ <a change>
++ General/Mutect2: Update default GATK (4.1.2.0) and picard (2.19.0) versions used in the pipeline that concern Mutect2

--- a/mutect2.wdl
+++ b/mutect2.wdl
@@ -19,8 +19,8 @@ workflow Mutect2 {
         File? regions
 
         Map[String, String] dockerImages = {
-          "picard":"quay.io/biocontainers/picard:2.18.26--0",
-          "gatk4":"quay.io/biocontainers/gatk4:4.1.0.0--0",
+          "picard":"quay.io/biocontainers/picard:2.19.0--0",
+          "gatk4":"quay.io/biocontainers/gatk4:4.1.2.0--1",
           "biopet-scatterregions":"quay.io/biocontainers/biopet-scatterregions:0.2--0"
         }
     }

--- a/somatic-variantcalling.wdl
+++ b/somatic-variantcalling.wdl
@@ -27,12 +27,12 @@ workflow SomaticVariantcalling {
         Boolean runMutect2 = true
 
         Map[String, String] dockerImages = {
-            "picard":"quay.io/biocontainers/picard:2.18.26--0",
+            "picard":"quay.io/biocontainers/picard:2.19.0--0",
             "biopet-scatterregions":"quay.io/biocontainers/biopet-scatterregions:0.2--0",
             "tabix":"quay.io/biocontainers/tabix:0.2.6--ha92aebf_0",
             "manta": "quay.io/biocontainers/manta:1.4.0--py27_1",
             "strelka": "quay.io/biocontainers/strelka:2.9.7--0",
-            "gatk4":"quay.io/biocontainers/gatk4:4.1.0.0--0",
+            "gatk4":"quay.io/biocontainers/gatk4:4.1.2.0--1",
             "vardict-java": "quay.io/biocontainers/vardict-java:1.5.8--1",
             "somaticseq": "lethalfang/somaticseq:3.1.0"
         }


### PR DESCRIPTION
This is was done to accommodate the Mutect2 update in version 4.1.2.0 of GATK which introduced meaningful changes (see https://gatkforums.broadinstitute.org/gatk/discussion/24057/how-to-call-somatic-mutations-using-gatk4-mutect2#latest).
The Picard version chosen is not the latest but is the one that comes prepackaged with GATK 4.1.2.0.

### Checklist
- [x] Pull request details were added to CHANGELOG.md
